### PR TITLE
Address runtime vs static analysis gap in dependency scanning

### DIFF
--- a/src/mcp_security_review/providers/sca/__init__.py
+++ b/src/mcp_security_review/providers/sca/__init__.py
@@ -3,7 +3,19 @@
 Package registry verification and vulnerability scanning via OSV.dev.
 """
 
+from .lockfile import LockfileParser, LockedDependency, LockfileParseResult, LockfileFormat
+from .markers import EnvMarkerEvaluator, EnvironmentContext, MarkerEvalResult
 from .osv import OSVScanner
 from .registry import PackageRegistry
 
-__all__ = ["OSVScanner", "PackageRegistry"]
+__all__ = [
+    "OSVScanner",
+    "PackageRegistry",
+    "LockfileParser",
+    "LockedDependency",
+    "LockfileParseResult",
+    "LockfileFormat",
+    "EnvMarkerEvaluator",
+    "EnvironmentContext",
+    "MarkerEvalResult",
+]

--- a/src/mcp_security_review/providers/sca/lockfile.py
+++ b/src/mcp_security_review/providers/sca/lockfile.py
@@ -1,0 +1,623 @@
+"""Lockfile parser for resolving actual runtime dependency graphs.
+
+Parses common lockfile formats to get the *resolved* dependency set
+(what's actually installed at runtime), not just the declared deps.
+
+Supports:
+- requirements.txt / requirements-*.txt  (with PEP 508 markers)
+- uv.lock  (TOML-based, uv package manager)
+- poetry.lock  (TOML-based, Poetry)
+- package-lock.json v2/v3  (npm)
+- yarn.lock  (Yarn classic and berry)
+- Pipfile.lock  (Pipenv)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class LockfileFormat(str, Enum):
+    REQUIREMENTS_TXT = "requirements.txt"
+    UV_LOCK = "uv.lock"
+    POETRY_LOCK = "poetry.lock"
+    PACKAGE_LOCK_JSON = "package-lock.json"
+    YARN_LOCK = "yarn.lock"
+    PIPFILE_LOCK = "Pipfile.lock"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class LockedDependency:
+    """A single dependency as resolved in a lockfile."""
+
+    name: str
+    version: str
+    ecosystem: str  # "pypi" or "npm"
+    is_direct: bool = False  # True if declared in project manifest, False if transitive
+    markers: str | None = None  # raw PEP 508 marker string, if any
+    extras: list[str] = field(default_factory=list)  # optional extras requested
+    source: str | None = None  # git/url source if not from registry
+
+    def to_dict(self) -> dict:
+        result: dict = {
+            "name": self.name,
+            "version": self.version,
+            "ecosystem": self.ecosystem,
+        }
+        if self.is_direct:
+            result["is_direct"] = True
+        if self.markers:
+            result["markers"] = self.markers
+        if self.extras:
+            result["extras"] = self.extras
+        if self.source:
+            result["source"] = self.source
+        return result
+
+
+@dataclass
+class LockfileParseResult:
+    """Result of parsing a lockfile."""
+
+    format: LockfileFormat
+    dependencies: list[LockedDependency]
+    warnings: list[str] = field(default_factory=list)
+    transitive_count: int = 0
+    direct_count: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "format": self.format.value,
+            "total_packages": len(self.dependencies),
+            "direct_count": self.direct_count,
+            "transitive_count": self.transitive_count,
+            "warnings": self.warnings,
+        }
+
+
+class LockfileParser:
+    """Detects and parses lockfiles to extract the resolved dependency graph."""
+
+    @classmethod
+    def detect_format(cls, filename: str, content: str) -> LockfileFormat:
+        """Detect the lockfile format from filename and content."""
+        name = Path(filename).name.lower()
+        if name == "uv.lock":
+            return LockfileFormat.UV_LOCK
+        if name == "poetry.lock":
+            return LockfileFormat.POETRY_LOCK
+        if name == "package-lock.json":
+            return LockfileFormat.PACKAGE_LOCK_JSON
+        if name == "yarn.lock":
+            return LockfileFormat.YARN_LOCK
+        if name == "pipfile.lock":
+            return LockfileFormat.PIPFILE_LOCK
+        if name.startswith("requirements") and name.endswith(".txt"):
+            return LockfileFormat.REQUIREMENTS_TXT
+        # Sniff content
+        if content.lstrip().startswith("{") and '"lockfileVersion"' in content:
+            return LockfileFormat.PACKAGE_LOCK_JSON
+        if "__metadata" in content and "version:" in content:
+            return LockfileFormat.YARN_LOCK
+        if "[[package]]" in content and 'name = "' in content:
+            return LockfileFormat.POETRY_LOCK
+        if "version = 1" in content and "[[package]]" in content:
+            return LockfileFormat.UV_LOCK
+        return LockfileFormat.UNKNOWN
+
+    @classmethod
+    def parse(cls, content: str, filename: str = "") -> LockfileParseResult:
+        """Parse a lockfile and return resolved dependencies."""
+        fmt = cls.detect_format(filename, content)
+        parsers = {
+            LockfileFormat.REQUIREMENTS_TXT: cls._parse_requirements_txt,
+            LockfileFormat.UV_LOCK: cls._parse_uv_lock,
+            LockfileFormat.POETRY_LOCK: cls._parse_poetry_lock,
+            LockfileFormat.PACKAGE_LOCK_JSON: cls._parse_package_lock_json,
+            LockfileFormat.YARN_LOCK: cls._parse_yarn_lock,
+            LockfileFormat.PIPFILE_LOCK: cls._parse_pipfile_lock,
+        }
+        parser_fn = parsers.get(fmt)
+        if parser_fn is None:
+            return LockfileParseResult(
+                format=LockfileFormat.UNKNOWN,
+                dependencies=[],
+                warnings=[f"Unrecognized lockfile format for '{filename}'"],
+            )
+        try:
+            deps, warnings = parser_fn(content)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Lockfile parse error for %s: %s", filename, e)
+            return LockfileParseResult(
+                format=fmt,
+                dependencies=[],
+                warnings=[f"Parse error: {e}"],
+            )
+        direct = sum(1 for d in deps if d.is_direct)
+        return LockfileParseResult(
+            format=fmt,
+            dependencies=deps,
+            warnings=warnings,
+            direct_count=direct,
+            transitive_count=len(deps) - direct,
+        )
+
+    # -------------------------------------------------------------------------
+    # requirements.txt
+    # -------------------------------------------------------------------------
+    @classmethod
+    def _parse_requirements_txt(
+        cls, content: str
+    ) -> tuple[list[LockedDependency], list[str]]:
+        """Parse requirements.txt format.
+
+        Handles:
+        - pkg==1.2.3
+        - pkg==1.2.3; python_version >= "3.8"  (PEP 508 markers)
+        - pkg[extra1,extra2]==1.2.3
+        - -r other-requirements.txt  (skipped with warning)
+        - # comments
+        - -e git+https://...  (skipped with warning)
+        """
+        deps: list[LockedDependency] = []
+        warnings: list[str] = []
+        # Matches: name[extras]==version ; markers
+        pattern = re.compile(
+            r"^(?P<name>[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?)"
+            r"(?:\[(?P<extras>[^\]]*)\])?"
+            r"\s*==\s*"
+            r"(?P<version>[^\s;#]+)"
+            r"(?:\s*;\s*(?P<markers>[^#\n]+))?",
+            re.MULTILINE,
+        )
+        for line in content.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("-r ") or line.startswith("--requirement"):
+                warnings.append(
+                    f"Nested requirements file not followed: {line}"
+                )
+                continue
+            if line.startswith("-e ") or line.startswith("--editable"):
+                warnings.append(f"Editable/VCS install skipped: {line}")
+                continue
+            m = pattern.match(line)
+            if m:
+                extras = [
+                    e.strip() for e in (m.group("extras") or "").split(",") if e.strip()
+                ]
+                deps.append(
+                    LockedDependency(
+                        name=m.group("name"),
+                        version=m.group("version"),
+                        ecosystem="pypi",
+                        is_direct=True,  # requirements.txt lists direct deps
+                        markers=(m.group("markers") or "").strip() or None,
+                        extras=extras,
+                    )
+                )
+            elif "==" not in line and line and not line.startswith("-"):
+                warnings.append(
+                    f"Skipped unpinned requirement: {line.split()[0]}"
+                )
+        return deps, warnings
+
+    # -------------------------------------------------------------------------
+    # uv.lock  (TOML-like, custom format)
+    # -------------------------------------------------------------------------
+    @classmethod
+    def _parse_uv_lock(
+        cls, content: str
+    ) -> tuple[list[LockedDependency], list[str]]:
+        """Parse uv.lock format.
+
+        uv.lock uses TOML-like sections:
+            [[package]]
+            name = "requests"
+            version = "2.31.0"
+            source = { registry = "https://pypi.org/simple" }
+
+        Direct deps are listed under [manifest] dependencies.
+        """
+        warnings: list[str] = []
+        deps: list[LockedDependency] = []
+
+        # Collect direct dep names from [manifest] section
+        direct_names: set[str] = set()
+        manifest_match = re.search(
+            r"\[manifest\].*?(?=\n\[|\Z)", content, re.DOTALL
+        )
+        if manifest_match:
+            manifest_text = manifest_match.group(0)
+            # dependencies = [...] multi-line array
+            dep_array = re.search(
+                r"dependencies\s*=\s*\[(.*?)\]", manifest_text, re.DOTALL
+            )
+            if dep_array:
+                for item in re.finditer(
+                    r'"([A-Za-z0-9][A-Za-z0-9._-]*)', dep_array.group(1)
+                ):
+                    direct_names.add(_normalize_pkg_name(item.group(1)))
+
+        # Parse each [[package]] block
+        package_blocks = re.split(r"\[\[package\]\]", content)
+        for block in package_blocks[1:]:  # skip preamble before first block
+            name_m = re.search(r'^name\s*=\s*"([^"]+)"', block, re.MULTILINE)
+            ver_m = re.search(r'^version\s*=\s*"([^"]+)"', block, re.MULTILINE)
+            if not name_m or not ver_m:
+                continue
+            name = name_m.group(1)
+            version = ver_m.group(1)
+            # Check for non-registry source (git, path, url)
+            source_m = re.search(r"^source\s*=\s*\{([^}]+)\}", block, re.MULTILINE)
+            source = None
+            if source_m:
+                source_text = source_m.group(1)
+                if "registry" not in source_text:
+                    source = source_text.strip()
+                    warnings.append(
+                        f"{name}@{version} installed from non-registry source: {source}"
+                    )
+            normalized = _normalize_pkg_name(name)
+            deps.append(
+                LockedDependency(
+                    name=name,
+                    version=version,
+                    ecosystem="pypi",
+                    is_direct=normalized in direct_names,
+                    source=source,
+                )
+            )
+        return deps, warnings
+
+    # -------------------------------------------------------------------------
+    # poetry.lock
+    # -------------------------------------------------------------------------
+    @classmethod
+    def _parse_poetry_lock(
+        cls, content: str
+    ) -> tuple[list[LockedDependency], list[str]]:
+        """Parse poetry.lock TOML format.
+
+        Direct packages are identified by "optional = false" in the standard
+        poetry lockfile (all non-optional deps are resolved by the solver).
+        Since poetry.lock doesn't distinguish direct vs transitive directly,
+        we mark everything as is_direct=False and note the limitation.
+        """
+        warnings: list[str] = [
+            "poetry.lock: direct vs transitive distinction requires "
+            "cross-referencing pyproject.toml [tool.poetry.dependencies] — "
+            "all deps marked as transitive here."
+        ]
+        deps: list[LockedDependency] = []
+        # Split on [[package]] blocks
+        blocks = re.split(r"\[\[package\]\]", content)
+        for block in blocks[1:]:
+            name_m = re.search(r'^name\s*=\s*"([^"]+)"', block, re.MULTILINE)
+            ver_m = re.search(r'^version\s*=\s*"([^"]+)"', block, re.MULTILINE)
+            if not name_m or not ver_m:
+                continue
+            name = name_m.group(1)
+            version = ver_m.group(1)
+            optional_m = re.search(r"^optional\s*=\s*(true|false)", block, re.MULTILINE)
+            is_optional = optional_m and optional_m.group(1) == "true"
+            extras_m = re.search(r'^extras\s*=\s*\[([^\]]*)\]', block, re.MULTILINE)
+            extras = []
+            if extras_m:
+                extras = [
+                    e.strip().strip('"')
+                    for e in extras_m.group(1).split(",")
+                    if e.strip().strip('"')
+                ]
+            if is_optional:
+                warnings.append(
+                    f"{name}@{version} is an optional dep — only present "
+                    "if requested via extras"
+                )
+            deps.append(
+                LockedDependency(
+                    name=name,
+                    version=version,
+                    ecosystem="pypi",
+                    is_direct=False,
+                    extras=extras,
+                )
+            )
+        return deps, warnings
+
+    # -------------------------------------------------------------------------
+    # package-lock.json (npm v2/v3)
+    # -------------------------------------------------------------------------
+    @classmethod
+    def _parse_package_lock_json(
+        cls, content: str
+    ) -> tuple[list[LockedDependency], list[str]]:
+        """Parse npm package-lock.json v2/v3 format."""
+        warnings: list[str] = []
+        deps: list[LockedDependency] = []
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            return deps, [f"JSON parse error: {e}"]
+
+        lock_version = data.get("lockfileVersion", 1)
+        if lock_version not in (2, 3):
+            warnings.append(
+                f"package-lock.json v{lock_version} detected — "
+                "only v2/v3 fully supported; attempting best-effort parse."
+            )
+
+        # v2/v3: "packages" dict
+        packages = data.get("packages", {})
+        for pkg_path, pkg_data in packages.items():
+            if not pkg_path:  # root package
+                continue
+            # Extract package name from path: "node_modules/foo" or "node_modules/@scope/foo"
+            name = _npm_path_to_name(pkg_path)
+            version = pkg_data.get("version", "")
+            if not version:
+                continue
+            is_dev = pkg_data.get("dev", False)
+            is_optional = pkg_data.get("optional", False)
+            resolved = pkg_data.get("resolved", "")
+            source = None
+            if resolved and not resolved.startswith("https://registry.npmjs.org"):
+                source = resolved
+                warnings.append(
+                    f"{name}@{version} resolved from non-registry source: {resolved}"
+                )
+            if is_optional:
+                warnings.append(
+                    f"{name}@{version} is an optional npm dep (may not be installed)"
+                )
+            # Determine if direct: top-level packages key starts with "node_modules/X"
+            # (not "node_modules/X/node_modules/Y")
+            is_direct = pkg_path.count("node_modules/") == 1
+            deps.append(
+                LockedDependency(
+                    name=name,
+                    version=version,
+                    ecosystem="npm",
+                    is_direct=is_direct,
+                    source=source,
+                )
+            )
+
+        # Fallback to v1 "dependencies" dict
+        if not deps and "dependencies" in data:
+            warnings.append("Falling back to v1 'dependencies' format")
+            cls._parse_npm_v1_deps(data.get("dependencies", {}), deps, warnings, depth=0)
+
+        return deps, warnings
+
+    @classmethod
+    def _parse_npm_v1_deps(
+        cls,
+        deps_dict: dict,
+        deps: list[LockedDependency],
+        warnings: list[str],
+        depth: int,
+    ) -> None:
+        """Recursively parse npm v1 nested dependencies."""
+        for name, pkg_data in deps_dict.items():
+            version = pkg_data.get("version", "")
+            if version:
+                deps.append(
+                    LockedDependency(
+                        name=name,
+                        version=version,
+                        ecosystem="npm",
+                        is_direct=(depth == 0),
+                    )
+                )
+            nested = pkg_data.get("dependencies", {})
+            if nested:
+                cls._parse_npm_v1_deps(nested, deps, warnings, depth + 1)
+
+    # -------------------------------------------------------------------------
+    # yarn.lock (classic v1 format)
+    # -------------------------------------------------------------------------
+    @classmethod
+    def _parse_yarn_lock(
+        cls, content: str
+    ) -> tuple[list[LockedDependency], list[str]]:
+        """Parse Yarn classic (v1) yarn.lock format.
+
+        Format:
+            package-name@^1.2.3:
+              version "1.2.4"
+              resolved "https://registry.yarnpkg.com/..."
+        """
+        warnings: list[str] = []
+        deps: list[LockedDependency] = []
+
+        if content.lstrip().startswith("{"):
+            # Yarn Berry v2+ uses a different YAML-ish format; simplified parse
+            warnings.append(
+                "Yarn Berry (v2+) format detected — basic name/version extraction only"
+            )
+            return cls._parse_yarn_berry(content, warnings)
+
+        # Yarn classic v1
+        current_names: list[str] = []
+        current_version: str | None = None
+
+        for line in content.splitlines():
+            line_stripped = line.strip()
+            if not line_stripped or line_stripped.startswith("#"):
+                if current_names and current_version:
+                    for name in current_names:
+                        deps.append(
+                            LockedDependency(
+                                name=name,
+                                version=current_version,
+                                ecosystem="npm",
+                                is_direct=False,  # yarn.lock doesn't distinguish
+                            )
+                        )
+                    current_names = []
+                    current_version = None
+                continue
+
+            if not line.startswith(" "):
+                # Entry header: "pkg-name@^1.0.0, pkg-name@~1.0.0:"
+                if current_names and current_version:
+                    for name in current_names:
+                        deps.append(
+                            LockedDependency(
+                                name=name,
+                                version=current_version,
+                                ecosystem="npm",
+                                is_direct=False,
+                            )
+                        )
+                current_names = []
+                current_version = None
+                header = line_stripped.rstrip(":")
+                for entry in header.split(","):
+                    entry = entry.strip()
+                    # Remove version specifier: "pkg@^1.0" -> "pkg"
+                    at_pos = entry.rfind("@")
+                    if at_pos > 0:
+                        name = entry[:at_pos]
+                    else:
+                        name = entry
+                    name = name.strip("\"'")
+                    if name:
+                        current_names.append(name)
+            else:
+                version_m = re.match(r'\s+version\s+"([^"]+)"', line)
+                if version_m:
+                    current_version = version_m.group(1)
+                resolved_m = re.match(r'\s+resolved\s+"([^"]+)"', line)
+                if resolved_m:
+                    resolved = resolved_m.group(1)
+                    if "registry.yarnpkg.com" not in resolved and "registry.npmjs.org" not in resolved:
+                        for name in current_names:
+                            warnings.append(
+                                f"{name} resolved from non-registry source: {resolved}"
+                            )
+
+        # Flush last block
+        if current_names and current_version:
+            for name in current_names:
+                deps.append(
+                    LockedDependency(
+                        name=name,
+                        version=current_version,
+                        ecosystem="npm",
+                        is_direct=False,
+                    )
+                )
+
+        if not deps:
+            warnings.append("No pinned packages found in yarn.lock")
+        else:
+            warnings.append(
+                "yarn.lock: direct vs transitive distinction requires "
+                "cross-referencing package.json — all deps marked as transitive."
+            )
+        return deps, warnings
+
+    @classmethod
+    def _parse_yarn_berry(
+        cls, content: str, warnings: list[str]
+    ) -> tuple[list[LockedDependency], list[str]]:
+        """Simplified parse for Yarn Berry YAML-ish format."""
+        deps: list[LockedDependency] = []
+        for m in re.finditer(
+            r'"?(?P<name>@?[a-z0-9][a-z0-9._-]*/[a-z0-9._-]+|[a-z0-9][a-z0-9._-]*)'
+            r'@[^"]+?"?\s*:\s*\n\s+version:\s+(?P<version>[^\n]+)',
+            content,
+        ):
+            deps.append(
+                LockedDependency(
+                    name=m.group("name"),
+                    version=m.group("version").strip(),
+                    ecosystem="npm",
+                    is_direct=False,
+                )
+            )
+        return deps, warnings
+
+    # -------------------------------------------------------------------------
+    # Pipfile.lock
+    # -------------------------------------------------------------------------
+    @classmethod
+    def _parse_pipfile_lock(
+        cls, content: str
+    ) -> tuple[list[LockedDependency], list[str]]:
+        """Parse Pipfile.lock JSON format."""
+        warnings: list[str] = []
+        deps: list[LockedDependency] = []
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            return deps, [f"JSON parse error: {e}"]
+
+        for section in ("default", "develop"):
+            section_data = data.get(section, {})
+            for name, pkg_data in section_data.items():
+                version_str = pkg_data.get("version", "")
+                # Pipfile.lock uses "==1.2.3" format
+                version = version_str.lstrip("=")
+                if not version:
+                    markers = pkg_data.get("markers", None)
+                    warnings.append(
+                        f"{name} has no pinned version in Pipfile.lock"
+                    )
+                    continue
+                markers = pkg_data.get("markers", None)
+                index = pkg_data.get("index", "")
+                source = None
+                if not index or index not in ("pypi", ""):
+                    ref = pkg_data.get("ref", pkg_data.get("git", ""))
+                    if ref:
+                        source = ref
+                        warnings.append(
+                            f"{name}@{version} installed from VCS/custom source"
+                        )
+                deps.append(
+                    LockedDependency(
+                        name=name,
+                        version=version,
+                        ecosystem="pypi",
+                        is_direct=True,  # Pipfile.lock only contains direct + resolved
+                        markers=markers,
+                        source=source,
+                    )
+                )
+        return deps, warnings
+
+
+def _normalize_pkg_name(name: str) -> str:
+    """Normalize package name per PEP 503 (lowercase, dashes/underscores/dots -> dash)."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _npm_path_to_name(path: str) -> str:
+    """Convert node_modules path to package name.
+
+    Examples:
+        node_modules/lodash -> lodash
+        node_modules/@scope/pkg -> @scope/pkg
+        node_modules/a/node_modules/@scope/b -> @scope/b
+    """
+    parts = path.split("node_modules/")
+    last = parts[-1].rstrip("/")
+    # Scoped package: @scope/pkg
+    if last.startswith("@") and "/" in last:
+        slash = last.index("/")
+        scope = last[:slash]
+        rest = last[slash + 1:].split("/")[0]
+        return f"{scope}/{rest}"
+    return last.split("/")[0]

--- a/src/mcp_security_review/providers/sca/lockfile.py
+++ b/src/mcp_security_review/providers/sca/lockfile.py
@@ -361,12 +361,12 @@ class LockfileParser:
         for pkg_path, pkg_data in packages.items():
             if not pkg_path:  # root package
                 continue
-            # Extract package name from path: "node_modules/foo" or "node_modules/@scope/foo"
+            # Extract package name from path:
+            # "node_modules/foo" or "node_modules/@scope/foo"
             name = _npm_path_to_name(pkg_path)
             version = pkg_data.get("version", "")
             if not version:
                 continue
-            is_dev = pkg_data.get("dev", False)
             is_optional = pkg_data.get("optional", False)
             resolved = pkg_data.get("resolved", "")
             source = None
@@ -395,7 +395,9 @@ class LockfileParser:
         # Fallback to v1 "dependencies" dict
         if not deps and "dependencies" in data:
             warnings.append("Falling back to v1 'dependencies' format")
-            cls._parse_npm_v1_deps(data.get("dependencies", {}), deps, warnings, depth=0)
+            cls._parse_npm_v1_deps(
+                data.get("dependencies", {}), deps, warnings, depth=0
+            )
 
         return deps, warnings
 
@@ -501,7 +503,8 @@ class LockfileParser:
                 resolved_m = re.match(r'\s+resolved\s+"([^"]+)"', line)
                 if resolved_m:
                     resolved = resolved_m.group(1)
-                    if "registry.yarnpkg.com" not in resolved and "registry.npmjs.org" not in resolved:
+                    known = ("registry.yarnpkg.com", "registry.npmjs.org")
+                    if not any(r in resolved for r in known):
                         for name in current_names:
                             warnings.append(
                                 f"{name} resolved from non-registry source: {resolved}"
@@ -600,7 +603,10 @@ class LockfileParser:
 
 
 def _normalize_pkg_name(name: str) -> str:
-    """Normalize package name per PEP 503 (lowercase, dashes/underscores/dots -> dash)."""
+    """Normalize package name per PEP 503.
+
+    Lowercases and collapses dashes/underscores/dots to a single dash.
+    """
     return re.sub(r"[-_.]+", "-", name).lower()
 
 

--- a/src/mcp_security_review/providers/sca/markers.py
+++ b/src/mcp_security_review/providers/sca/markers.py
@@ -15,10 +15,13 @@ Reference: https://peps.python.org/pep-0508/#environment-markers
 
 from __future__ import annotations
 
+import logging
 import platform
 import re
 import sys
 from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -62,7 +65,7 @@ class EnvironmentContext:
         python_version: str = "3.11",
         sys_platform: str = "linux",
         platform_machine: str = "x86_64",
-    ) -> "EnvironmentContext":
+    ) -> EnvironmentContext:
         """Create an environment context representing a typical Linux container."""
         major, minor = python_version.split(".")[:2]
         return cls(
@@ -190,8 +193,8 @@ class EnvMarkerEvaluator:
                             active=True,
                             reason=f"Active with extra='{extra_val}'",
                         )
-                except Exception as e:  # noqa: BLE001
-                    pass
+                except Exception:  # noqa: BLE001, S110
+                    logger.debug("Marker eval failed for extra=%r", extra_val)
             return MarkerEvalResult(
                 marker=marker,
                 active=False,
@@ -203,10 +206,11 @@ class EnvMarkerEvaluator:
             reason = self._explain(marker, env_dict, result)
             return MarkerEvalResult(marker=marker, active=result, reason=reason)
         except Exception as e:  # noqa: BLE001
+            reason = f"Could not evaluate marker: {e} — assuming active (conservative)"
             return MarkerEvalResult(
                 marker=marker,
                 active=True,  # conservative: assume active if we can't evaluate
-                reason=f"Could not evaluate marker: {e} — assuming active (conservative)",
+                reason=reason,
                 uncertain=True,
             )
 
@@ -322,8 +326,10 @@ class EnvMarkerEvaluator:
                 lhs = expr[:idx].strip()
                 rhs = expr[idx + len(op):].strip().strip("\"'")
                 lhs_val = env.get(lhs, lhs.strip("\"'"))
-                return self._compare(lhs_val, op, rhs, lhs in self._VERSION_VARS)
-        raise ValueError(f"Cannot parse marker comparison: {expr!r}")
+                version_compare = lhs in self._VERSION_VARS
+                return self._compare(lhs_val, op, rhs, version_compare)
+        msg = f"Cannot parse marker comparison: {expr!r}"
+        raise ValueError(msg)
 
     def _find_op(self, expr: str, op: str) -> int:
         """Find operator position, ignoring quoted strings."""
@@ -359,7 +365,7 @@ class EnvMarkerEvaluator:
         lhs: str,
         op: str,
         rhs: str,
-        is_version: bool,
+        is_version: bool,  # noqa: FBT001
     ) -> bool:
         """Perform the actual comparison."""
         if op == "in":
@@ -385,7 +391,8 @@ class EnvMarkerEvaluator:
                     return lhs_v >= rhs_v
                 if op == "~=":
                     # Compatible release: >= rhs, == rhs.*
-                    return lhs_v >= rhs_v and lhs_v[: len(rhs_v) - 1] == rhs_v[: len(rhs_v) - 1]
+                    prefix = len(rhs_v) - 1
+                    return lhs_v >= rhs_v and lhs_v[:prefix] == rhs_v[:prefix]
             except (ValueError, IndexError):
                 pass  # Fall through to string comparison
 
@@ -405,7 +412,7 @@ class EnvMarkerEvaluator:
             return lhs_s >= rhs_s
         return False
 
-    def _explain(self, marker: str, env: dict[str, str], result: bool) -> str:
+    def _explain(self, marker: str, env: dict[str, str], result: bool) -> str:  # noqa: FBT001
         """Generate a human-readable explanation of the evaluation."""
         status = "active" if result else "not active"
         # Extract the key variable for a simple one-liner

--- a/src/mcp_security_review/providers/sca/markers.py
+++ b/src/mcp_security_review/providers/sca/markers.py
@@ -1,0 +1,435 @@
+"""PEP 508 environment marker evaluator.
+
+Evaluates dependency markers like:
+    python_version >= "3.8"
+    sys_platform == "linux"
+    extra == "dev"
+    python_version >= "3.8" and sys_platform != "win32"
+
+Used to determine whether a conditional dependency is actually
+active in the current (or a target) environment, so we can filter
+the lockfile to what's *really* loaded at runtime.
+
+Reference: https://peps.python.org/pep-0508/#environment-markers
+"""
+
+from __future__ import annotations
+
+import platform
+import re
+import sys
+from dataclasses import dataclass, field
+
+
+@dataclass
+class EnvironmentContext:
+    """Runtime environment for evaluating PEP 508 markers.
+
+    Defaults to the current interpreter's environment.
+    Pass explicit values to evaluate for a *target* environment
+    (e.g. a container running Python 3.11 on linux/amd64).
+    """
+
+    python_version: str = field(
+        default_factory=lambda: f"{sys.version_info.major}.{sys.version_info.minor}"
+    )
+    python_full_version: str = field(
+        default_factory=lambda: (
+            f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        )
+    )
+    python_version_tuple: tuple[int, ...] = field(
+        default_factory=lambda: sys.version_info[:3]
+    )
+    os_name: str = field(default_factory=lambda: platform.system().lower())
+    sys_platform: str = field(
+        default_factory=lambda: sys.platform
+    )
+    platform_machine: str = field(
+        default_factory=lambda: platform.machine()
+    )
+    platform_python_implementation: str = field(
+        default_factory=lambda: platform.python_implementation()
+    )
+    implementation_name: str = field(
+        default_factory=lambda: platform.python_implementation().lower()
+    )
+    extras: list[str] = field(default_factory=list)
+
+    @classmethod
+    def for_container(
+        cls,
+        python_version: str = "3.11",
+        sys_platform: str = "linux",
+        platform_machine: str = "x86_64",
+    ) -> "EnvironmentContext":
+        """Create an environment context representing a typical Linux container."""
+        major, minor = python_version.split(".")[:2]
+        return cls(
+            python_version=f"{major}.{minor}",
+            python_full_version=f"{major}.{minor}.0",
+            python_version_tuple=(int(major), int(minor), 0),
+            os_name="posix",
+            sys_platform=sys_platform,
+            platform_machine=platform_machine,
+            platform_python_implementation="CPython",
+            implementation_name="cpython",
+        )
+
+    def to_marker_env(self) -> dict[str, str]:
+        """Return the marker variable dict for evaluation."""
+        return {
+            "python_version": self.python_version,
+            "python_full_version": self.python_full_version,
+            "os_name": self.os_name,
+            "sys_platform": self.sys_platform,
+            "platform_machine": self.platform_machine,
+            "platform_python_implementation": self.platform_python_implementation,
+            "implementation_name": self.implementation_name,
+            "platform_release": "",
+            "platform_system": self.os_name.capitalize(),
+            "platform_version": "",
+            "extra": "",  # overridden in evaluate_for_extras
+        }
+
+
+@dataclass
+class MarkerEvalResult:
+    """Result of evaluating a PEP 508 marker."""
+
+    marker: str
+    active: bool  # True if this dep is loaded in the target environment
+    reason: str
+    # When active is uncertain (e.g. dynamic extras), flag it
+    uncertain: bool = False
+
+    def to_dict(self) -> dict:
+        result: dict = {
+            "marker": self.marker,
+            "active": self.active,
+            "reason": self.reason,
+        }
+        if self.uncertain:
+            result["uncertain"] = True
+        return result
+
+
+class EnvMarkerEvaluator:
+    """Evaluates PEP 508 environment markers against a runtime context.
+
+    Handles:
+    - Comparison operators: ==, !=, <, <=, >, >=, ~=, in, not in
+    - Boolean operators: and, or, not
+    - All standard PEP 508 marker variables
+    - Version comparisons (semver-aware)
+    - Extra markers (with known extras list)
+    """
+
+    # Marker variables that take string (non-version) values
+    _STRING_VARS = frozenset(
+        {
+            "os_name",
+            "sys_platform",
+            "platform_machine",
+            "platform_python_implementation",
+            "implementation_name",
+            "platform_release",
+            "platform_system",
+            "platform_version",
+            "extra",
+        }
+    )
+
+    # Marker variables that take version values
+    _VERSION_VARS = frozenset(
+        {
+            "python_version",
+            "python_full_version",
+            "implementation_version",
+        }
+    )
+
+    def evaluate(
+        self,
+        marker: str,
+        env: EnvironmentContext | None = None,
+    ) -> MarkerEvalResult:
+        """Evaluate a PEP 508 marker string.
+
+        Returns MarkerEvalResult with active=True if the dep should
+        be installed in the given environment.
+        """
+        if not marker or not marker.strip():
+            return MarkerEvalResult(
+                marker=marker, active=True, reason="No marker — always active"
+            )
+        env = env or EnvironmentContext()
+        env_dict = env.to_marker_env()
+
+        # Check for extra marker — needs special handling
+        has_extra = "extra" in marker
+        if has_extra and not env.extras:
+            return MarkerEvalResult(
+                marker=marker,
+                active=False,
+                reason=(
+                    "Marker references 'extra' but no extras were requested — "
+                    "optional dep not active. Pass extras= to check specific extras."
+                ),
+                uncertain=False,
+            )
+        if has_extra and env.extras:
+            # Evaluate for each requested extra; active if any match
+            for extra_val in env.extras:
+                env_dict["extra"] = extra_val
+                try:
+                    result = self._eval_expr(marker, env_dict)
+                    if result:
+                        return MarkerEvalResult(
+                            marker=marker,
+                            active=True,
+                            reason=f"Active with extra='{extra_val}'",
+                        )
+                except Exception as e:  # noqa: BLE001
+                    pass
+            return MarkerEvalResult(
+                marker=marker,
+                active=False,
+                reason=f"Not active for extras {env.extras}",
+            )
+
+        try:
+            result = self._eval_expr(marker, env_dict)
+            reason = self._explain(marker, env_dict, result)
+            return MarkerEvalResult(marker=marker, active=result, reason=reason)
+        except Exception as e:  # noqa: BLE001
+            return MarkerEvalResult(
+                marker=marker,
+                active=True,  # conservative: assume active if we can't evaluate
+                reason=f"Could not evaluate marker: {e} — assuming active (conservative)",
+                uncertain=True,
+            )
+
+    def filter_active(
+        self,
+        deps: list,  # list[LockedDependency]
+        env: EnvironmentContext | None = None,
+    ) -> tuple[list, list[str]]:
+        """Filter a list of LockedDependency to those active in the environment.
+
+        Returns (active_deps, skipped_reasons).
+        """
+        from mcp_security_review.providers.sca.lockfile import LockedDependency
+
+        env = env or EnvironmentContext()
+        active: list[LockedDependency] = []
+        skipped: list[str] = []
+
+        for dep in deps:
+            if not dep.markers:
+                active.append(dep)
+                continue
+            result = self.evaluate(dep.markers, env)
+            if result.active:
+                active.append(dep)
+            else:
+                skipped.append(
+                    f"{dep.name}@{dep.version} skipped: {result.reason}"
+                )
+
+        return active, skipped
+
+    # -------------------------------------------------------------------------
+    # Internal evaluation
+    # -------------------------------------------------------------------------
+    def _eval_expr(self, expr: str, env: dict[str, str]) -> bool:
+        """Recursively evaluate a marker expression."""
+        expr = expr.strip()
+
+        # Handle parenthesized groups
+        expr = self._strip_outer_parens(expr)
+
+        # Boolean operators (lowest precedence first)
+        for op in (" or ", " and "):
+            parts = self._split_on_boolean(expr, op.strip())
+            if parts:
+                results = [self._eval_expr(p, env) for p in parts]
+                if op.strip() == "or":
+                    return any(results)
+                else:
+                    return all(results)
+
+        # "not" prefix
+        if expr.lower().startswith("not "):
+            return not self._eval_expr(expr[4:], env)
+
+        # Single comparison
+        return self._eval_comparison(expr, env)
+
+    def _split_on_boolean(self, expr: str, op: str) -> list[str] | None:
+        """Split expression on boolean operator, respecting parentheses depth."""
+        depth = 0
+        op_lower = f" {op} "
+        i = 0
+        positions = []
+        while i < len(expr):
+            ch = expr[i]
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+            elif depth == 0:
+                if expr[i : i + len(op_lower)].lower() == op_lower:
+                    positions.append(i)
+                    i += len(op_lower)
+                    continue
+            i += 1
+        if not positions:
+            return None
+        parts = []
+        prev = 0
+        for pos in positions:
+            parts.append(expr[prev:pos].strip())
+            prev = pos + len(op_lower)
+        parts.append(expr[prev:].strip())
+        return parts
+
+    def _strip_outer_parens(self, expr: str) -> str:
+        """Remove matching outer parentheses if they wrap the whole expression."""
+        while expr.startswith("(") and expr.endswith(")"):
+            # Make sure the opening paren matches the closing paren
+            depth = 0
+            for i, ch in enumerate(expr):
+                if ch == "(":
+                    depth += 1
+                elif ch == ")":
+                    depth -= 1
+                if depth == 0 and i < len(expr) - 1:
+                    return expr  # inner close before end — not wrapping parens
+            expr = expr[1:-1].strip()
+        return expr
+
+    def _eval_comparison(self, expr: str, env: dict[str, str]) -> bool:
+        """Evaluate a single comparison like 'python_version >= "3.8"'."""
+        # Operator order matters: longer first to avoid partial matches
+        operators = [
+            "not in", "in", "~=", "!=", "==", "<=", ">=", "<", ">",
+        ]
+        for op in operators:
+            # Find op not inside quotes
+            idx = self._find_op(expr, op)
+            if idx >= 0:
+                lhs = expr[:idx].strip()
+                rhs = expr[idx + len(op):].strip().strip("\"'")
+                lhs_val = env.get(lhs, lhs.strip("\"'"))
+                return self._compare(lhs_val, op, rhs, lhs in self._VERSION_VARS)
+        raise ValueError(f"Cannot parse marker comparison: {expr!r}")
+
+    def _find_op(self, expr: str, op: str) -> int:
+        """Find operator position, ignoring quoted strings."""
+        in_quote = None
+        i = 0
+        while i < len(expr):
+            ch = expr[i]
+            if ch in ('"', "'"):
+                if in_quote == ch:
+                    in_quote = None
+                elif in_quote is None:
+                    in_quote = ch
+            elif in_quote is None:
+                if expr[i : i + len(op)] == op:
+                    # Make sure it's not part of a longer operator
+                    before = expr[i - 1] if i > 0 else " "
+                    after = expr[i + len(op)] if i + len(op) < len(expr) else " "
+                    if op in ("in", "not in"):
+                        # Must be surrounded by spaces
+                        if before == " " and after == " ":
+                            return i
+                    elif op in ("<", ">"):
+                        # Avoid matching <= or >=
+                        if after not in ("=", "<", ">"):
+                            return i
+                    else:
+                        return i
+            i += 1
+        return -1
+
+    def _compare(
+        self,
+        lhs: str,
+        op: str,
+        rhs: str,
+        is_version: bool,
+    ) -> bool:
+        """Perform the actual comparison."""
+        if op == "in":
+            return lhs in rhs
+        if op == "not in":
+            return lhs not in rhs
+
+        if is_version:
+            try:
+                lhs_v = _parse_version(lhs)
+                rhs_v = _parse_version(rhs)
+                if op == "==":
+                    return lhs_v == rhs_v
+                if op == "!=":
+                    return lhs_v != rhs_v
+                if op == "<":
+                    return lhs_v < rhs_v
+                if op == "<=":
+                    return lhs_v <= rhs_v
+                if op == ">":
+                    return lhs_v > rhs_v
+                if op == ">=":
+                    return lhs_v >= rhs_v
+                if op == "~=":
+                    # Compatible release: >= rhs, == rhs.*
+                    return lhs_v >= rhs_v and lhs_v[: len(rhs_v) - 1] == rhs_v[: len(rhs_v) - 1]
+            except (ValueError, IndexError):
+                pass  # Fall through to string comparison
+
+        lhs_s = lhs.lower()
+        rhs_s = rhs.lower()
+        if op == "==":
+            return lhs_s == rhs_s
+        if op == "!=":
+            return lhs_s != rhs_s
+        if op == "<":
+            return lhs_s < rhs_s
+        if op == "<=":
+            return lhs_s <= rhs_s
+        if op == ">":
+            return lhs_s > rhs_s
+        if op == ">=":
+            return lhs_s >= rhs_s
+        return False
+
+    def _explain(self, marker: str, env: dict[str, str], result: bool) -> str:
+        """Generate a human-readable explanation of the evaluation."""
+        status = "active" if result else "not active"
+        # Extract the key variable for a simple one-liner
+        var_match = re.search(
+            r"(python_version|sys_platform|platform_machine|os_name|extra)\s*"
+            r"([=!<>~]+|not in|in)\s*['\"]([^'\"]+)['\"]",
+            marker,
+        )
+        if var_match:
+            var, op, val = var_match.groups()
+            env_val = env.get(var, "?")
+            return f"{status}: {var}={env_val!r} {op} {val!r}"
+        return f"{status} in target environment"
+
+
+def _parse_version(version_str: str) -> tuple[int, ...]:
+    """Parse a version string into a comparable tuple of ints."""
+    # Strip pre/post/dev suffixes for comparison
+    clean = re.sub(r"[a-zA-Z+].*$", "", version_str)
+    parts = clean.split(".")
+    result = []
+    for p in parts:
+        try:
+            result.append(int(p))
+        except ValueError:
+            break
+    return tuple(result) if result else (0,)

--- a/src/mcp_security_review/providers/sca/osv.py
+++ b/src/mcp_security_review/providers/sca/osv.py
@@ -40,6 +40,7 @@ class ReachabilityStatus:
     AI_ANALYSIS_REQUIRED = "ai_analysis_required"
     NO_CODE_PROVIDED = "no_code_provided"
     UNCERTAIN = "uncertain"  # AI analyzed but could not definitively determine
+    DYNAMIC_IMPORT = "dynamic_import"  # Package loaded via dynamic import — static analysis cannot confirm
 
 
 @dataclass
@@ -461,6 +462,22 @@ class OSVScanner:
                 )
             ]
 
+        # If import was detected via a dynamic pattern, flag it and ask AI
+        if import_evidence and import_evidence.startswith("DYNAMIC:"):
+            prompt = self._build_ai_reachability_prompt(
+                vuln, package_name, code, import_evidence
+            )
+            return [
+                ReachabilityResult(
+                    status=ReachabilityStatus.DYNAMIC_IMPORT,
+                    evidence=(
+                        f"{package_name} appears to be loaded dynamically — "
+                        f"static analysis cannot confirm reachability. {import_evidence}"
+                    ),
+                    reachability_prompt=prompt,
+                )
+            ]
+
         # Step 2: OSV gave us specific function symbols — do static check
         if vuln.vulnerable_functions:
             results = []
@@ -521,6 +538,10 @@ class OSVScanner:
         """Check if a package is imported anywhere in the code.
 
         alt_names: alternative import names (e.g. pyjwt -> {"jwt"}).
+
+        Also detects dynamic imports (importlib, __import__, require() with
+        variable arg) and returns a sentinel evidence string so the caller
+        can flag the result as DYNAMIC_IMPORT status.
         """
         names_to_check = [package_name] + list(alt_names or set())
 
@@ -534,6 +555,12 @@ class OSVScanner:
                     m = re.search(p, code, re.MULTILINE | re.IGNORECASE)
                     if m:
                         return True, f"Imported: {m.group().strip()}"
+
+            # Dynamic import patterns for Python
+            dyn_evidence = self._find_dynamic_import(package_name, ecosystem, code, alt_names)
+            if dyn_evidence:
+                return True, dyn_evidence
+
             return False, f"'{package_name}' not found in any import statement"
 
         elif ecosystem == "npm":
@@ -547,6 +574,12 @@ class OSVScanner:
                     m = re.search(p, code)
                     if m:
                         return True, f"Imported: {m.group().strip()}"
+
+            # Dynamic import patterns for JS/TS
+            dyn_evidence = self._find_dynamic_import(package_name, ecosystem, code, alt_names)
+            if dyn_evidence:
+                return True, dyn_evidence
+
             return False, f"'{package_name}' not found in any import/require"
 
         else:
@@ -554,6 +587,98 @@ class OSVScanner:
                 if re.search(re.escape(name), code, re.IGNORECASE):
                     return True, f"'{name}' referenced in code"
             return False, f"'{package_name}' not referenced in code"
+
+    def _find_dynamic_import(
+        self,
+        package_name: str,
+        ecosystem: str,
+        code: str,
+        alt_names: set[str] | None = None,
+    ) -> str | None:
+        """Detect dynamic import patterns that static regex misses.
+
+        Returns an evidence string prefixed with 'DYNAMIC:' if found,
+        None otherwise.
+
+        Python patterns detected:
+        - importlib.import_module("pkg") / importlib.import_module('pkg')
+        - __import__("pkg")
+        - importlib.import_module(variable)  — flagged as uncertain
+        - exec()/eval() calls  — flagged as uncertain if package name nearby
+
+        JS/TS patterns detected:
+        - import("pkg")  dynamic import()
+        - require(variable)  — flagged as uncertain
+        - require.resolve("pkg")
+        - await import("pkg")
+        """
+        names_to_check = [package_name] + list(alt_names or set())
+
+        if ecosystem == "PyPI":
+            for name in names_to_check:
+                pkg = re.escape(name)
+                # importlib.import_module("pkg") or importlib.import_module('pkg')
+                m = re.search(
+                    rf"""importlib\.import_module\s*\(\s*['\"]{pkg}['\"]""",
+                    code,
+                )
+                if m:
+                    return f"DYNAMIC: importlib.import_module('{name}') — {m.group().strip()}"
+
+                # __import__("pkg")
+                m = re.search(
+                    rf"""__import__\s*\(\s*['\"]{pkg}['\"]""",
+                    code,
+                )
+                if m:
+                    return f"DYNAMIC: __import__('{name}') — {m.group().strip()}"
+
+            # Generic dynamic load indicators (uncertain — no specific package name)
+            # importlib.import_module(variable) where variable might contain our pkg
+            if re.search(r"importlib\.import_module\s*\(\s*[^'\"]", code):
+                return (
+                    f"DYNAMIC: importlib.import_module(variable) detected — "
+                    f"cannot confirm if '{package_name}' is loaded dynamically"
+                )
+            # exec/eval with package name appearing in the expression
+            for name in names_to_check:
+                m = re.search(
+                    rf"""(?:exec|eval)\s*\([\s\S]{{0,500}}?\b{re.escape(name)}\b""",
+                    code,
+                )
+                if m:
+                    return (
+                        f"DYNAMIC: exec/eval with '{name}' reference — "
+                        f"package may be loaded dynamically"
+                    )
+
+        elif ecosystem == "npm":
+            for name in names_to_check:
+                pkg = re.escape(name)
+                # Dynamic import(): import("pkg") or await import("pkg")
+                m = re.search(
+                    rf"""import\s*\(\s*['\"]{pkg}['\"]""",
+                    code,
+                )
+                if m:
+                    return f"DYNAMIC: import('{name}') — {m.group().strip()}"
+
+                # require.resolve("pkg")
+                m = re.search(
+                    rf"""require\.resolve\s*\(\s*['\"]{pkg}['\"]""",
+                    code,
+                )
+                if m:
+                    return f"DYNAMIC: require.resolve('{name}') — {m.group().strip()}"
+
+            # require(variable) — uncertain
+            if re.search(r"require\s*\(\s*[^'\"`]", code):
+                return (
+                    f"DYNAMIC: require(variable) detected — "
+                    f"cannot confirm if '{package_name}' is loaded dynamically"
+                )
+
+        return None
 
     def _is_function_called(
         self,

--- a/src/mcp_security_review/providers/sca/osv.py
+++ b/src/mcp_security_review/providers/sca/osv.py
@@ -40,7 +40,8 @@ class ReachabilityStatus:
     AI_ANALYSIS_REQUIRED = "ai_analysis_required"
     NO_CODE_PROVIDED = "no_code_provided"
     UNCERTAIN = "uncertain"  # AI analyzed but could not definitively determine
-    DYNAMIC_IMPORT = "dynamic_import"  # Package loaded via dynamic import — static analysis cannot confirm
+    # Package loaded via dynamic import — static analysis cannot confirm
+    DYNAMIC_IMPORT = "dynamic_import"
 
 
 @dataclass
@@ -472,7 +473,8 @@ class OSVScanner:
                     status=ReachabilityStatus.DYNAMIC_IMPORT,
                     evidence=(
                         f"{package_name} appears to be loaded dynamically — "
-                        f"static analysis cannot confirm reachability. {import_evidence}"
+                        "static analysis cannot confirm reachability. "
+                        f"{import_evidence}"
                     ),
                     reachability_prompt=prompt,
                 )
@@ -557,7 +559,9 @@ class OSVScanner:
                         return True, f"Imported: {m.group().strip()}"
 
             # Dynamic import patterns for Python
-            dyn_evidence = self._find_dynamic_import(package_name, ecosystem, code, alt_names)
+            dyn_evidence = self._find_dynamic_import(
+                package_name, ecosystem, code, alt_names
+            )
             if dyn_evidence:
                 return True, dyn_evidence
 
@@ -576,7 +580,9 @@ class OSVScanner:
                         return True, f"Imported: {m.group().strip()}"
 
             # Dynamic import patterns for JS/TS
-            dyn_evidence = self._find_dynamic_import(package_name, ecosystem, code, alt_names)
+            dyn_evidence = self._find_dynamic_import(
+                package_name, ecosystem, code, alt_names
+            )
             if dyn_evidence:
                 return True, dyn_evidence
 
@@ -623,7 +629,8 @@ class OSVScanner:
                     code,
                 )
                 if m:
-                    return f"DYNAMIC: importlib.import_module('{name}') — {m.group().strip()}"
+                    matched = m.group().strip()
+                    return f"DYNAMIC: importlib.import_module('{name}') — {matched}"
 
                 # __import__("pkg")
                 m = re.search(

--- a/src/mcp_security_review/servers/sca.py
+++ b/src/mcp_security_review/servers/sca.py
@@ -13,8 +13,8 @@ from fastmcp import Context, FastMCP
 from pydantic import Field
 
 from mcp_security_review.providers.sca import (
-    EnvMarkerEvaluator,
     EnvironmentContext,
+    EnvMarkerEvaluator,
     LockfileParser,
     OSVScanner,
     PackageRegistry,

--- a/src/mcp_security_review/servers/sca.py
+++ b/src/mcp_security_review/servers/sca.py
@@ -12,7 +12,13 @@ from typing import Annotated
 from fastmcp import Context, FastMCP
 from pydantic import Field
 
-from mcp_security_review.providers.sca import OSVScanner, PackageRegistry
+from mcp_security_review.providers.sca import (
+    EnvMarkerEvaluator,
+    EnvironmentContext,
+    LockfileParser,
+    OSVScanner,
+    PackageRegistry,
+)
 from mcp_security_review.providers.sca.osv import ReachabilityStatus, ScanResult
 
 logger = logging.getLogger(__name__)
@@ -36,7 +42,11 @@ async def _resolve_ai_reachability(ctx: Context, results: list[ScanResult]) -> N
         for vuln in scan_result.vulnerabilities:
             for reach in vuln.reachability:
                 if (
-                    reach.status == ReachabilityStatus.AI_ANALYSIS_REQUIRED
+                    reach.status
+                    in (
+                        ReachabilityStatus.AI_ANALYSIS_REQUIRED,
+                        ReachabilityStatus.DYNAMIC_IMPORT,
+                    )
                     and reach.reachability_prompt
                 ):
                     try:
@@ -261,6 +271,224 @@ async def scan_dependencies(
             "Provide code snippets where these packages are used "
             "to enable reachability analysis and determine if "
             "vulnerable functions are actually called."
+        )
+
+    return json.dumps(response, indent=2, ensure_ascii=False)
+
+
+@sca_mcp.tool(tags={"security", "sca", "lockfile", "runtime"})
+async def scan_lockfile(
+    ctx: Context,
+    lockfile_content: Annotated[
+        str,
+        Field(
+            description=(
+                "Content of the lockfile to parse and scan. Supported formats: "
+                "requirements.txt, uv.lock, poetry.lock, package-lock.json, "
+                "yarn.lock, Pipfile.lock."
+            )
+        ),
+    ],
+    lockfile_name: Annotated[
+        str,
+        Field(
+            description=(
+                "Filename of the lockfile (e.g. 'requirements.txt', 'uv.lock'). "
+                "Used to detect format."
+            ),
+            default="requirements.txt",
+        ),
+    ] = "requirements.txt",
+    target_python_version: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Target Python version to evaluate environment markers against, "
+                "e.g. '3.11'. Defaults to current interpreter version. "
+                "Use this to simulate what's installed in a container."
+            ),
+            default=None,
+        ),
+    ] = None,
+    target_platform: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Target sys.platform for marker evaluation, e.g. 'linux', 'win32', "
+                "'darwin'. Defaults to current platform."
+            ),
+            default=None,
+        ),
+    ] = None,
+    extras: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Comma-separated list of package extras to activate when evaluating "
+                "optional dependency markers, e.g. 'security,async'."
+            ),
+            default=None,
+        ),
+    ] = None,
+    code_snippets: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Optional JSON array of code snippet strings to enable reachability "
+                "analysis on vulnerable packages found in the lockfile."
+            ),
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Scan a lockfile to find CVEs in the *actual* resolved dependency graph.
+
+    Addresses the static vs runtime analysis gap by:
+    1. Parsing the lockfile to get all *resolved* packages (direct + transitive)
+    2. Evaluating PEP 508 environment markers to filter deps inactive in the
+       target environment (e.g. Windows-only deps on a Linux container)
+    3. Flagging packages installed from non-registry sources (git, path, URL)
+       which may diverge from the published version at runtime
+    4. Scanning all active packages against OSV.dev for known CVEs
+    5. Optionally running reachability analysis if code snippets are provided
+
+    Use this tool when you need to audit what's *actually loaded at runtime*
+    rather than just what's declared in pyproject.toml or package.json.
+
+    Args:
+        ctx: The FastMCP context.
+        lockfile_content: Raw content of the lockfile.
+        lockfile_name: Filename hint for format detection.
+        target_python_version: Python version to evaluate markers against.
+        target_platform: sys.platform for marker evaluation.
+        extras: Comma-separated extras to activate.
+        code_snippets: Optional JSON array of code for reachability analysis.
+
+    Returns:
+        JSON with:
+        - Lockfile format detected
+        - Total/active/skipped package counts
+        - Packages skipped due to inactive env markers
+        - Non-registry sources flagged (potential drift)
+        - CVE findings with reachability status
+    """
+    # Parse lockfile
+    parse_result = LockfileParser.parse(lockfile_content, lockfile_name)
+
+    if not parse_result.dependencies:
+        return json.dumps(
+            {
+                "format": parse_result.format.value,
+                "error": "No pinned packages found in lockfile",
+                "warnings": parse_result.warnings,
+            },
+            indent=2,
+        )
+
+    # Build environment context for marker evaluation
+    if target_python_version or target_platform:
+        env = EnvironmentContext.for_container(
+            python_version=target_python_version or "3.11",
+            sys_platform=target_platform or "linux",
+        )
+    else:
+        env = EnvironmentContext()
+
+    if extras:
+        env.extras = [e.strip() for e in extras.split(",") if e.strip()]
+
+    # Evaluate markers to get the runtime-active subset
+    evaluator = EnvMarkerEvaluator()
+    active_deps, skipped_reasons = evaluator.filter_active(
+        parse_result.dependencies, env
+    )
+
+    # Collect non-registry sources (potential drift points)
+    drift_warnings = [
+        f"{dep.name}@{dep.version}: non-registry source — {dep.source}"
+        for dep in active_deps
+        if dep.source
+    ]
+
+    # Prepare packages for OSV scanning
+    packages_to_scan = [
+        {"name": dep.name, "version": dep.version, "ecosystem": dep.ecosystem}
+        for dep in active_deps
+    ]
+
+    # Parse code snippets
+    snippets = None
+    if code_snippets:
+        try:
+            snippets = json.loads(code_snippets)
+            if not isinstance(snippets, list):
+                snippets = [str(snippets)]
+        except json.JSONDecodeError:
+            snippets = [code_snippets]
+
+    # Scan all active packages
+    scanner = OSVScanner()
+    scan_results = await scanner.scan_packages(packages_to_scan, snippets)
+
+    if snippets:
+        await _resolve_ai_reachability(ctx, scan_results)
+
+    vulnerable = [r for r in scan_results if r.has_vulnerabilities]
+    reachable = [r for r in scan_results if r.has_reachable_vulnerabilities]
+
+    response: dict = {
+        "lockfile_format": parse_result.format.value,
+        "total_packages_in_lockfile": len(parse_result.dependencies),
+        "direct_packages": parse_result.direct_count,
+        "transitive_packages": parse_result.transitive_count,
+        "active_after_marker_eval": len(active_deps),
+        "skipped_by_markers": len(skipped_reasons),
+        "non_registry_sources": len(drift_warnings),
+        "packages_scanned": len(scan_results),
+        "vulnerable_count": len(vulnerable),
+    }
+
+    if parse_result.warnings:
+        response["lockfile_warnings"] = parse_result.warnings
+
+    if skipped_reasons:
+        response["marker_filtered_deps"] = skipped_reasons
+
+    if drift_warnings:
+        response["runtime_drift_risk"] = drift_warnings
+        response["drift_warning"] = (
+            "These packages are installed from non-registry sources (git, path, URL). "
+            "The resolved version at build time may differ from what's running in "
+            "production. Verify these match your expected versions."
+        )
+
+    if not vulnerable:
+        response["status"] = "clean"
+        response["message"] = (
+            f"No known vulnerabilities in {len(active_deps)} active packages "
+            f"(from {len(parse_result.dependencies)} total in lockfile)."
+        )
+        return json.dumps(response, indent=2, ensure_ascii=False)
+
+    response["status"] = "vulnerabilities_found"
+    response["results"] = [r.to_dict() for r in vulnerable]
+
+    if snippets:
+        response["reachable_count"] = len(reachable)
+        if reachable:
+            response["action_required"] = (
+                "URGENT: Vulnerable functions are reachable in your code. "
+                "Upgrade the affected packages immediately."
+            )
+        else:
+            response["recommendation"] = (
+                "Vulnerabilities found but not directly reachable in the provided "
+                "code. Upgrade as a precaution, especially transitive dependencies."
+            )
+    else:
+        response["recommendation"] = (
+            "Provide code_snippets to enable reachability analysis and determine "
+            "which of these CVEs are actually exploitable in your codebase."
         )
 
     return json.dumps(response, indent=2, ensure_ascii=False)

--- a/tests/unit/providers/sca/test_lockfile.py
+++ b/tests/unit/providers/sca/test_lockfile.py
@@ -1,0 +1,319 @@
+"""Tests for LockfileParser — runtime dependency graph resolution."""
+
+import pytest
+
+from mcp_security_review.providers.sca.lockfile import (
+    LockfileFormat,
+    LockfileParser,
+    LockedDependency,
+    _normalize_pkg_name,
+    _npm_path_to_name,
+)
+
+
+class TestFormatDetection:
+    def test_detect_uv_lock_by_name(self) -> None:
+        assert LockfileParser.detect_format("uv.lock", "") == LockfileFormat.UV_LOCK
+
+    def test_detect_poetry_lock_by_name(self) -> None:
+        assert LockfileParser.detect_format("poetry.lock", "") == LockfileFormat.POETRY_LOCK
+
+    def test_detect_package_lock_by_name(self) -> None:
+        assert (
+            LockfileParser.detect_format("package-lock.json", "")
+            == LockfileFormat.PACKAGE_LOCK_JSON
+        )
+
+    def test_detect_yarn_lock_by_name(self) -> None:
+        assert LockfileParser.detect_format("yarn.lock", "") == LockfileFormat.YARN_LOCK
+
+    def test_detect_pipfile_lock_by_name(self) -> None:
+        assert LockfileParser.detect_format("Pipfile.lock", "") == LockfileFormat.PIPFILE_LOCK
+
+    def test_detect_requirements_txt(self) -> None:
+        assert (
+            LockfileParser.detect_format("requirements.txt", "")
+            == LockfileFormat.REQUIREMENTS_TXT
+        )
+
+    def test_detect_requirements_dev_txt(self) -> None:
+        assert (
+            LockfileParser.detect_format("requirements-dev.txt", "")
+            == LockfileFormat.REQUIREMENTS_TXT
+        )
+
+    def test_detect_package_lock_by_content(self) -> None:
+        content = '{"lockfileVersion": 2, "packages": {}}'
+        assert (
+            LockfileParser.detect_format("lockfile", content)
+            == LockfileFormat.PACKAGE_LOCK_JSON
+        )
+
+    def test_detect_poetry_lock_by_content(self) -> None:
+        content = '[[package]]\nname = "requests"\nversion = "2.31.0"\n'
+        assert LockfileParser.detect_format("lockfile", content) == LockfileFormat.POETRY_LOCK
+
+    def test_unknown_format(self) -> None:
+        assert LockfileParser.detect_format("random.file", "nothing") == LockfileFormat.UNKNOWN
+
+
+class TestRequirementsTxtParser:
+    def test_simple_pinned(self) -> None:
+        content = "requests==2.31.0\nhttpx==0.24.0\n"
+        result = LockfileParser.parse(content, "requirements.txt")
+        assert result.format == LockfileFormat.REQUIREMENTS_TXT
+        assert len(result.dependencies) == 2
+        names = {d.name for d in result.dependencies}
+        assert names == {"requests", "httpx"}
+
+    def test_version_extracted(self) -> None:
+        content = "pyjwt==2.4.0\n"
+        result = LockfileParser.parse(content, "requirements.txt")
+        assert result.dependencies[0].version == "2.4.0"
+
+    def test_env_marker_preserved(self) -> None:
+        content = 'pywin32==305; sys_platform == "win32"\n'
+        result = LockfileParser.parse(content, "requirements.txt")
+        assert len(result.dependencies) == 1
+        dep = result.dependencies[0]
+        assert dep.name == "pywin32"
+        assert dep.markers == 'sys_platform == "win32"'
+
+    def test_extras_extracted(self) -> None:
+        content = "requests[security]==2.31.0\n"
+        result = LockfileParser.parse(content, "requirements.txt")
+        assert result.dependencies[0].extras == ["security"]
+
+    def test_comments_ignored(self) -> None:
+        content = "# This is a comment\nrequests==2.31.0\n"
+        result = LockfileParser.parse(content, "requirements.txt")
+        assert len(result.dependencies) == 1
+
+    def test_unpinned_generates_warning(self) -> None:
+        content = "requests>=2.0\n"
+        result = LockfileParser.parse(content, "requirements.txt")
+        assert len(result.dependencies) == 0
+        assert any("unpinned" in w for w in result.warnings)
+
+    def test_nested_requirements_warning(self) -> None:
+        content = "-r base.txt\nrequests==2.31.0\n"
+        result = LockfileParser.parse(content, "requirements.txt")
+        assert any("Nested requirements" in w for w in result.warnings)
+
+    def test_all_direct(self) -> None:
+        content = "requests==2.31.0\nhttpx==0.24.0\n"
+        result = LockfileParser.parse(content, "requirements.txt")
+        assert all(d.is_direct for d in result.dependencies)
+        assert result.direct_count == 2
+
+    def test_ecosystem_is_pypi(self) -> None:
+        content = "requests==2.31.0\n"
+        result = LockfileParser.parse(content, "requirements.txt")
+        assert result.dependencies[0].ecosystem == "pypi"
+
+
+class TestUvLockParser:
+    def _make_uv_lock(self, packages: list[tuple[str, str]]) -> str:
+        lines = ["version = 1\n\n[manifest]\ndependencies = ["]
+        lines.append(f'  "{packages[0][0]}",')
+        lines.append("]\n")
+        for name, version in packages:
+            lines.append("[[package]]")
+            lines.append(f'name = "{name}"')
+            lines.append(f'version = "{version}"')
+            lines.append('source = { registry = "https://pypi.org/simple" }\n')
+        return "\n".join(lines)
+
+    def test_parses_packages(self) -> None:
+        content = self._make_uv_lock([("requests", "2.31.0"), ("httpx", "0.24.0")])
+        result = LockfileParser.parse(content, "uv.lock")
+        assert result.format == LockfileFormat.UV_LOCK
+        assert len(result.dependencies) == 2
+
+    def test_version_extracted(self) -> None:
+        content = self._make_uv_lock([("pyjwt", "2.4.0")])
+        result = LockfileParser.parse(content, "uv.lock")
+        assert result.dependencies[0].version == "2.4.0"
+
+    def test_non_registry_source_warning(self) -> None:
+        content = (
+            "version = 1\n\n[[package]]\n"
+            'name = "mypkg"\nversion = "1.0.0"\n'
+            'source = { git = "https://github.com/foo/bar.git#abc123" }\n'
+        )
+        result = LockfileParser.parse(content, "uv.lock")
+        assert any("non-registry source" in w for w in result.warnings)
+
+    def test_ecosystem_is_pypi(self) -> None:
+        content = self._make_uv_lock([("requests", "2.31.0")])
+        result = LockfileParser.parse(content, "uv.lock")
+        assert result.dependencies[0].ecosystem == "pypi"
+
+
+class TestPoetryLockParser:
+    def _make_poetry_lock(self, packages: list[tuple[str, str]]) -> str:
+        blocks = []
+        for name, version in packages:
+            blocks.append(
+                f'[[package]]\nname = "{name}"\nversion = "{version}"\n'
+                f'optional = false\npython-versions = ">=3.8"\n'
+            )
+        return "\n".join(blocks)
+
+    def test_parses_packages(self) -> None:
+        content = self._make_poetry_lock([("requests", "2.31.0"), ("httpx", "0.24.0")])
+        result = LockfileParser.parse(content, "poetry.lock")
+        assert result.format == LockfileFormat.POETRY_LOCK
+        assert len(result.dependencies) == 2
+
+    def test_optional_dep_warning(self) -> None:
+        content = (
+            '[[package]]\nname = "cryptography"\nversion = "41.0.0"\n'
+            "optional = true\n"
+        )
+        result = LockfileParser.parse(content, "poetry.lock")
+        assert any("optional" in w for w in result.warnings)
+
+    def test_direct_transitive_limitation_warning(self) -> None:
+        content = self._make_poetry_lock([("requests", "2.31.0")])
+        result = LockfileParser.parse(content, "poetry.lock")
+        assert any("transitive" in w for w in result.warnings)
+
+
+class TestPackageLockJsonParser:
+    def _make_package_lock(self, packages: dict[str, str]) -> str:
+        import json
+        pkgs: dict[str, dict] = {}
+        for name, version in packages.items():
+            pkgs[f"node_modules/{name}"] = {
+                "version": version,
+                "resolved": f"https://registry.npmjs.org/{name}/-/{name}-{version}.tgz",
+            }
+        return json.dumps({"lockfileVersion": 2, "packages": pkgs})
+
+    def test_parses_packages(self) -> None:
+        content = self._make_package_lock({"lodash": "4.17.21", "express": "4.18.2"})
+        result = LockfileParser.parse(content, "package-lock.json")
+        assert result.format == LockfileFormat.PACKAGE_LOCK_JSON
+        assert len(result.dependencies) == 2
+
+    def test_ecosystem_is_npm(self) -> None:
+        content = self._make_package_lock({"lodash": "4.17.21"})
+        result = LockfileParser.parse(content, "package-lock.json")
+        assert result.dependencies[0].ecosystem == "npm"
+
+    def test_direct_package_detected(self) -> None:
+        content = self._make_package_lock({"lodash": "4.17.21"})
+        result = LockfileParser.parse(content, "package-lock.json")
+        assert result.dependencies[0].is_direct is True
+
+    def test_transitive_detected(self) -> None:
+        import json
+        pkgs = {
+            "node_modules/express": {"version": "4.18.2"},
+            "node_modules/express/node_modules/qs": {"version": "6.11.0"},
+        }
+        content = json.dumps({"lockfileVersion": 2, "packages": pkgs})
+        result = LockfileParser.parse(content, "package-lock.json")
+        direct = [d for d in result.dependencies if d.is_direct]
+        transitive = [d for d in result.dependencies if not d.is_direct]
+        assert len(direct) == 1
+        assert len(transitive) == 1
+
+    def test_non_registry_source_flagged(self) -> None:
+        import json
+        pkgs = {
+            "node_modules/mypkg": {
+                "version": "1.0.0",
+                "resolved": "https://github.com/foo/bar/tarball/abc123",
+            }
+        }
+        content = json.dumps({"lockfileVersion": 2, "packages": pkgs})
+        result = LockfileParser.parse(content, "package-lock.json")
+        assert any("non-registry" in w for w in result.warnings)
+
+    def test_invalid_json_returns_warning(self) -> None:
+        result = LockfileParser.parse("not json", "package-lock.json")
+        assert any("parse error" in w.lower() for w in result.warnings)
+
+
+class TestYarnLockParser:
+    def test_simple_yarn_v1(self) -> None:
+        content = (
+            "# yarn lockfile v1\n\n"
+            'lodash@^4.17.0:\n  version "4.17.21"\n'
+            '  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz"\n\n'
+        )
+        result = LockfileParser.parse(content, "yarn.lock")
+        assert result.format == LockfileFormat.YARN_LOCK
+        assert len(result.dependencies) == 1
+        assert result.dependencies[0].version == "4.17.21"
+        assert result.dependencies[0].name == "lodash"
+
+    def test_scoped_package(self) -> None:
+        content = (
+            '"@types/node@^18.0.0":\n  version "18.11.0"\n'
+            '  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.0.tgz"\n\n'
+        )
+        result = LockfileParser.parse(content, "yarn.lock")
+        assert result.dependencies[0].name == "@types/node"
+
+    def test_non_registry_source_flagged(self) -> None:
+        content = (
+            "mypkg@github:org/repo:\n  version \"1.0.0\"\n"
+            "  resolved \"https://github.com/org/repo/tarball/abc#abc\"\n\n"
+        )
+        result = LockfileParser.parse(content, "yarn.lock")
+        assert any("non-registry" in w for w in result.warnings)
+
+
+class TestPipfileLockParser:
+    def test_parses_default_deps(self) -> None:
+        import json
+        data = {
+            "_meta": {},
+            "default": {
+                "requests": {"version": "==2.31.0", "index": "pypi"},
+                "httpx": {"version": "==0.24.0", "index": "pypi"},
+            },
+            "develop": {},
+        }
+        result = LockfileParser.parse(json.dumps(data), "Pipfile.lock")
+        assert result.format == LockfileFormat.PIPFILE_LOCK
+        assert len(result.dependencies) == 2
+
+    def test_markers_preserved(self) -> None:
+        import json
+        data = {
+            "default": {
+                "pywin32": {
+                    "version": "==305",
+                    "markers": 'sys_platform == "win32"',
+                    "index": "pypi",
+                }
+            },
+            "develop": {},
+        }
+        result = LockfileParser.parse(json.dumps(data), "Pipfile.lock")
+        assert result.dependencies[0].markers == 'sys_platform == "win32"'
+
+
+class TestHelpers:
+    def test_normalize_pkg_name(self) -> None:
+        assert _normalize_pkg_name("PyJWT") == "pyjwt"
+        assert _normalize_pkg_name("my-package") == "my-package"
+        assert _normalize_pkg_name("my_package") == "my-package"
+        assert _normalize_pkg_name("my.package") == "my-package"
+        assert _normalize_pkg_name("My--Package") == "my-package"
+
+    def test_npm_path_to_name_simple(self) -> None:
+        assert _npm_path_to_name("node_modules/lodash") == "lodash"
+
+    def test_npm_path_to_name_scoped(self) -> None:
+        assert _npm_path_to_name("node_modules/@scope/pkg") == "@scope/pkg"
+
+    def test_npm_path_to_name_nested(self) -> None:
+        assert _npm_path_to_name("node_modules/a/node_modules/b") == "b"
+
+    def test_npm_path_to_name_scoped_nested(self) -> None:
+        assert _npm_path_to_name("node_modules/express/node_modules/@scope/pkg") == "@scope/pkg"

--- a/tests/unit/providers/sca/test_markers.py
+++ b/tests/unit/providers/sca/test_markers.py
@@ -1,0 +1,209 @@
+"""Tests for EnvMarkerEvaluator — PEP 508 marker evaluation."""
+
+import pytest
+
+from mcp_security_review.providers.sca.lockfile import LockedDependency
+from mcp_security_review.providers.sca.markers import (
+    EnvMarkerEvaluator,
+    EnvironmentContext,
+    _parse_version,
+)
+
+
+class TestVersionParsing:
+    def test_simple(self) -> None:
+        assert _parse_version("3.11") == (3, 11)
+
+    def test_full(self) -> None:
+        assert _parse_version("3.11.2") == (3, 11, 2)
+
+    def test_with_suffix(self) -> None:
+        assert _parse_version("3.8.0b1") == (3, 8, 0)
+
+    def test_empty(self) -> None:
+        assert _parse_version("") == (0,)
+
+
+class TestEnvironmentContext:
+    def test_defaults_to_current_env(self) -> None:
+        import sys
+        env = EnvironmentContext()
+        major, minor = env.python_version.split(".")
+        assert int(major) == sys.version_info.major
+        assert int(minor) == sys.version_info.minor
+
+    def test_for_container(self) -> None:
+        env = EnvironmentContext.for_container(
+            python_version="3.11",
+            sys_platform="linux",
+            platform_machine="aarch64",
+        )
+        assert env.python_version == "3.11"
+        assert env.sys_platform == "linux"
+        assert env.platform_machine == "aarch64"
+        assert env.os_name == "posix"
+
+    def test_to_marker_env(self) -> None:
+        env = EnvironmentContext.for_container("3.11", "linux")
+        d = env.to_marker_env()
+        assert d["python_version"] == "3.11"
+        assert d["sys_platform"] == "linux"
+        assert "extra" in d
+
+
+class TestEnvMarkerEvaluator:
+    def setup_method(self) -> None:
+        self.ev = EnvMarkerEvaluator()
+        self.linux_311 = EnvironmentContext.for_container("3.11", "linux")
+        self.win_38 = EnvironmentContext.for_container("3.8", "win32")
+
+    # ------ Empty marker ------
+    def test_empty_marker_always_active(self) -> None:
+        r = self.ev.evaluate("", self.linux_311)
+        assert r.active is True
+
+    def test_none_marker_active(self) -> None:
+        r = self.ev.evaluate(None, self.linux_311)  # type: ignore[arg-type]
+        assert r.active is True
+
+    # ------ python_version comparisons ------
+    def test_python_version_gte_active(self) -> None:
+        r = self.ev.evaluate('python_version >= "3.8"', self.linux_311)
+        assert r.active is True
+
+    def test_python_version_gte_inactive(self) -> None:
+        r = self.ev.evaluate('python_version >= "3.12"', self.linux_311)
+        assert r.active is False
+
+    def test_python_version_eq(self) -> None:
+        r = self.ev.evaluate('python_version == "3.11"', self.linux_311)
+        assert r.active is True
+
+    def test_python_version_lt(self) -> None:
+        r = self.ev.evaluate('python_version < "3.10"', self.linux_311)
+        assert r.active is False
+
+    def test_python_version_ne(self) -> None:
+        r = self.ev.evaluate('python_version != "3.11"', self.linux_311)
+        assert r.active is False
+
+    # ------ sys_platform ------
+    def test_sys_platform_eq_linux(self) -> None:
+        r = self.ev.evaluate('sys_platform == "linux"', self.linux_311)
+        assert r.active is True
+
+    def test_sys_platform_eq_win32_inactive_on_linux(self) -> None:
+        r = self.ev.evaluate('sys_platform == "win32"', self.linux_311)
+        assert r.active is False
+
+    def test_sys_platform_ne(self) -> None:
+        r = self.ev.evaluate('sys_platform != "win32"', self.linux_311)
+        assert r.active is True
+
+    # ------ Boolean combinations ------
+    def test_and_both_true(self) -> None:
+        r = self.ev.evaluate(
+            'python_version >= "3.8" and sys_platform == "linux"',
+            self.linux_311,
+        )
+        assert r.active is True
+
+    def test_and_one_false(self) -> None:
+        r = self.ev.evaluate(
+            'python_version >= "3.8" and sys_platform == "win32"',
+            self.linux_311,
+        )
+        assert r.active is False
+
+    def test_or_first_true(self) -> None:
+        r = self.ev.evaluate(
+            'sys_platform == "linux" or sys_platform == "win32"',
+            self.linux_311,
+        )
+        assert r.active is True
+
+    def test_or_both_false(self) -> None:
+        r = self.ev.evaluate(
+            'sys_platform == "darwin" or sys_platform == "win32"',
+            self.linux_311,
+        )
+        assert r.active is False
+
+    # ------ Parenthesized expressions ------
+    def test_parenthesized(self) -> None:
+        r = self.ev.evaluate(
+            '(python_version >= "3.8") and (sys_platform == "linux")',
+            self.linux_311,
+        )
+        assert r.active is True
+
+    # ------ extra markers ------
+    def test_extra_no_extras_requested(self) -> None:
+        r = self.ev.evaluate('extra == "security"', self.linux_311)
+        assert r.active is False
+        assert "optional" in r.reason.lower() or "extras" in r.reason.lower()
+
+    def test_extra_with_matching_extra(self) -> None:
+        env = EnvironmentContext.for_container("3.11", "linux")
+        env.extras = ["security"]
+        r = self.ev.evaluate('extra == "security"', env)
+        assert r.active is True
+
+    def test_extra_with_non_matching_extra(self) -> None:
+        env = EnvironmentContext.for_container("3.11", "linux")
+        env.extras = ["async"]
+        r = self.ev.evaluate('extra == "security"', env)
+        assert r.active is False
+
+    # ------ in / not in ------
+    def test_in_operator(self) -> None:
+        r = self.ev.evaluate('sys_platform in "linux darwin"', self.linux_311)
+        assert r.active is True
+
+    def test_not_in_operator(self) -> None:
+        r = self.ev.evaluate('sys_platform not in "win32 darwin"', self.linux_311)
+        assert r.active is True
+
+    # ------ Windows-specific deps on Linux container ------
+    def test_windows_dep_inactive_on_linux(self) -> None:
+        r = self.ev.evaluate('sys_platform == "win32"', self.linux_311)
+        assert r.active is False
+        assert "not active" in r.reason or "active" in r.reason
+
+    def test_windows_dep_active_on_windows(self) -> None:
+        r = self.ev.evaluate('sys_platform == "win32"', self.win_38)
+        assert r.active is True
+
+    # ------ filter_active ------
+    def test_filter_active_removes_inactive(self) -> None:
+        deps = [
+            LockedDependency(
+                name="pywin32", version="305", ecosystem="pypi",
+                markers='sys_platform == "win32"'
+            ),
+            LockedDependency(name="requests", version="2.31.0", ecosystem="pypi"),
+        ]
+        active, skipped = self.ev.filter_active(deps, self.linux_311)
+        assert len(active) == 1
+        assert active[0].name == "requests"
+        assert len(skipped) == 1
+        assert "pywin32" in skipped[0]
+
+    def test_filter_active_keeps_all_when_matching(self) -> None:
+        deps = [
+            LockedDependency(
+                name="requests", version="2.31.0", ecosystem="pypi",
+                markers='python_version >= "3.8"'
+            ),
+        ]
+        active, skipped = self.ev.filter_active(deps, self.linux_311)
+        assert len(active) == 1
+        assert len(skipped) == 0
+
+    def test_filter_active_no_markers(self) -> None:
+        deps = [
+            LockedDependency(name="requests", version="2.31.0", ecosystem="pypi"),
+        ]
+        active, skipped = self.ev.filter_active(deps, self.linux_311)
+        assert len(active) == 1
+        assert len(skipped) == 0

--- a/tests/unit/providers/sca/test_osv.py
+++ b/tests/unit/providers/sca/test_osv.py
@@ -420,3 +420,115 @@ class TestReachabilityAnalysis:
         )
         assert results[0].status == ReachabilityStatus.REACHABLE
         assert "FileResponse" in (results[0].evidence or "")
+
+
+class TestDynamicImportDetection:
+    """Test detection of dynamic import patterns."""
+
+    @pytest.fixture
+    def scanner(self) -> OSVScanner:
+        return OSVScanner()
+
+    def _make_vuln(self, functions: list[VulnerableFunction] | None = None) -> Vulnerability:
+        return Vulnerability(
+            id="TEST-DYN-001",
+            summary="Test vulnerability",
+            severity="high",
+            vulnerable_functions=functions or [],
+        )
+
+    # ------ Python dynamic imports ------
+    def test_importlib_import_module_detected(self, scanner: OSVScanner) -> None:
+        code = "import importlib\nmod = importlib.import_module('pyjwt')"
+        vuln = self._make_vuln()
+        results = scanner._determine_reachability(
+            vuln, "pyjwt", "PyPI", code, has_code=True
+        )
+        assert results[0].status == ReachabilityStatus.DYNAMIC_IMPORT
+        assert "DYNAMIC" in (results[0].evidence or "")
+        assert results[0].reachability_prompt is not None
+
+    def test_dunder_import_detected(self, scanner: OSVScanner) -> None:
+        code = "mod = __import__('requests')"
+        vuln = self._make_vuln()
+        results = scanner._determine_reachability(
+            vuln, "requests", "PyPI", code, has_code=True
+        )
+        assert results[0].status == ReachabilityStatus.DYNAMIC_IMPORT
+
+    def test_importlib_variable_flagged(self, scanner: OSVScanner) -> None:
+        code = "import importlib\npkg_name = get_pkg()\nmod = importlib.import_module(pkg_name)"
+        vuln = self._make_vuln()
+        results = scanner._determine_reachability(
+            vuln, "pyjwt", "PyPI", code, has_code=True
+        )
+        # Cannot confirm specific package but dynamic pattern detected
+        assert results[0].status == ReachabilityStatus.DYNAMIC_IMPORT
+
+    def test_exec_with_package_name_flagged(self, scanner: OSVScanner) -> None:
+        code = "exec(\"import pyjwt; pyjwt.decode(token, key)\")"
+        vuln = self._make_vuln()
+        results = scanner._determine_reachability(
+            vuln, "pyjwt", "PyPI", code, has_code=True
+        )
+        assert results[0].status == ReachabilityStatus.DYNAMIC_IMPORT
+
+    def test_static_import_still_works_with_dynamic_present(
+        self, scanner: OSVScanner
+    ) -> None:
+        """Static import takes priority over dynamic import detection."""
+        code = "import jwt\ntoken = jwt.decode(t, k, algorithms=['HS256'])"
+        vf = VulnerableFunction(name="decode", module="jwt")
+        vuln = self._make_vuln([vf])
+        results = scanner._determine_reachability(
+            vuln, "pyjwt", "PyPI", code, has_code=True
+        )
+        # Static import found first — should be REACHABLE, not DYNAMIC_IMPORT
+        assert results[0].status == ReachabilityStatus.REACHABLE
+
+    # ------ JS dynamic imports ------
+    def test_js_dynamic_import_detected(self, scanner: OSVScanner) -> None:
+        code = "const mod = await import('lodash');"
+        vuln = self._make_vuln()
+        results = scanner._determine_reachability(
+            vuln, "lodash", "npm", code, has_code=True
+        )
+        assert results[0].status == ReachabilityStatus.DYNAMIC_IMPORT
+
+    def test_js_require_resolve_detected(self, scanner: OSVScanner) -> None:
+        code = "const path = require.resolve('lodash');"
+        vuln = self._make_vuln()
+        results = scanner._determine_reachability(
+            vuln, "lodash", "npm", code, has_code=True
+        )
+        assert results[0].status == ReachabilityStatus.DYNAMIC_IMPORT
+
+    def test_js_require_variable_flagged(self, scanner: OSVScanner) -> None:
+        code = "const pkgName = getPkg();\nconst mod = require(pkgName);"
+        vuln = self._make_vuln()
+        results = scanner._determine_reachability(
+            vuln, "lodash", "npm", code, has_code=True
+        )
+        assert results[0].status == ReachabilityStatus.DYNAMIC_IMPORT
+
+    def test_js_static_import_not_dynamic(self, scanner: OSVScanner) -> None:
+        """Static require() with a literal string should NOT be flagged as dynamic."""
+        code = "const _ = require('lodash');\n_.template(input);"
+        vf = VulnerableFunction(name="template", module="lodash")
+        vuln = self._make_vuln([vf])
+        results = scanner._determine_reachability(
+            vuln, "lodash", "npm", code, has_code=True
+        )
+        assert results[0].status == ReachabilityStatus.REACHABLE
+
+    # ------ find_dynamic_import directly ------
+    def test_find_dynamic_returns_none_when_absent(self, scanner: OSVScanner) -> None:
+        code = "import requests\nresp = requests.get('https://example.com')"
+        result = scanner._find_dynamic_import("requests", "PyPI", code, set())
+        assert result is None
+
+    def test_find_dynamic_import_module_with_string(self, scanner: OSVScanner) -> None:
+        code = "importlib.import_module('yaml')"
+        result = scanner._find_dynamic_import("yaml", "PyPI", code, set())
+        assert result is not None
+        assert "DYNAMIC" in result


### PR DESCRIPTION
Closes the gap between what static/AST analysis thinks is reachable
and what's actually loaded at runtime.
Changes:
- providers/sca/lockfile.py: New LockfileParser supporting requirements.txt,
  uv.lock, poetry.lock, package-lock.json (v2/v3), yarn.lock (v1/v2),
  and Pipfile.lock. Extracts resolved (direct + transitive) deps and flags
  non-registry sources (git, path, URL) as potential runtime drift points.

- providers/sca/markers.py: New EnvMarkerEvaluator implementing PEP 508
  marker evaluation (python_version, sys_platform, extra, etc.) with version
  comparison and boolean operator support. Includes EnvironmentContext with a
  for_container() factory to simulate target environments (e.g. Python 3.11
  on linux/amd64) for accurate marker filtering.

- providers/sca/osv.py: Extended _is_package_imported() with dynamic import
  detection for Python (importlib.import_module, __import__, exec/eval) and
  JS/TS (dynamic import(), require.resolve, require(variable)). Returns new
  DYNAMIC_IMPORT reachability status — triggers AI analysis prompt since
  static regex cannot prove these paths definitively.

- servers/sca.py: New scan_lockfile() MCP tool that parses a lockfile,
  evaluates env markers against a target environment, flags non-registry
  sources, and scans all active (marker-matched) packages via OSV.dev.
  AI reachability resolution now also handles DYNAMIC_IMPORT status.
